### PR TITLE
implement pre-training

### DIFF
--- a/docs/pre_executed/testing/baselinecls_testing_runtime_config.toml
+++ b/docs/pre_executed/testing/baselinecls_testing_runtime_config.toml
@@ -3,8 +3,9 @@ name = "applecider.models.HyraxBaselineCLS.HyraxBaselineCLS"
 
 [model.HyraxBaselineCLS]
 use_probabilities = false
-use_pretrained_weights = true
-pretrained_weights_path = "./pretrained_weights.pth"
+
+# Use a pretrained weights file, if path is specified
+pretrained_weights_path = "./pretrained_weights.pth"  # false | <path_to_weights_file>
 
 # pre-training values
 lambda_f = 5.0

--- a/docs/pre_executed/testing/run_baselineCLS.py
+++ b/docs/pre_executed/testing/run_baselineCLS.py
@@ -15,7 +15,7 @@ h = Hyrax(config_file=toml_path)
 dataset = h.prepare()
 
 # Perform Pre-Training
-perform_pretrain = True
+perform_pretrain = False
 if perform_pretrain:
     pretrain_weights_path = h.config["model"]["HyraxBaselineCLS"]["pretrained_weights_path"]
     # Prepare empty state_dict for model

--- a/src/applecider/models/HyraxBaselineCLS.py
+++ b/src/applecider/models/HyraxBaselineCLS.py
@@ -40,7 +40,7 @@ class HyraxBaselineCLS(nn.Module):
 
         self.optimizer = torch.optim.Adam(self.parameters(), lr=1e-4)
 
-        if self.config["model"]["HyraxBaselineCLS"]["use_pretrained_weights"]:
+        if self.config["model"]["HyraxBaselineCLS"]["pretrained_weights_path"]:
             pretrained_path = self.config["model"]["HyraxBaselineCLS"]["pretrained_weights_path"]
             state_dict = torch.load(pretrained_path)
             self.load_state_dict(state_dict, strict=False)


### PR DESCRIPTION
Implements pre-training for BaselineCLS. Verification of results on delta still TBD.

This PR implements a pre-trainer model that can be run with hyrax as well, with the main driver script facilitating the pre-training process and generation of a weights file that is directly usable by the HyraxBaselineCLS model. The same config is used for both models, with a switch being required to properly drive the pretrainer (see the script)