### PR TITLE
Updating AppleCider to use current Hyrax

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v6

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v6

--- a/docs/pre_executed/testing/astrominn_example_config.toml
+++ b/docs/pre_executed/testing/astrominn_example_config.toml
@@ -1,27 +1,22 @@
 [model]
 name = "applecider.models.astrominn.AstroMiNN"
 
-[data_set]
-train_size = 1.0
-validate_size = 0.0
-test_size = 0.0
-
-[model_inputs]
-[model_inputs.train.data]
+[data_request]
+[data_request.train.data]
 dataset_class = "applecider.datasets.image_and_metadata_dataset.ImageAndMetadataDataset"
 data_location = "../../../data/preprocessed_ztf_alerts"
 fields = ["image", "metadata", "target", "obj_id"]
 primary_id_field = "obj_id"
-[model_inputs.train.data.dataset_config]
+split_fraction = 1.0
+[data_request.train.data.dataset_config.applecider.image_and_metadata_dataset]
 use_oversampling = true
+class_distribution = [0.3, 0.1, 0.1, 0.3, 0.1]
 
-[model_inputs.infer.data]
+
+[data_request.infer.data]
 dataset_class = "applecider.datasets.image_and_metadata_dataset.ImageAndMetadataDataset"
 data_location = "../../../data/preprocessed_ztf_alerts"
 fields = ["image", "metadata", "obj_id"]
 primary_id_field = "obj_id"
-[model_inputs.infer.data.dataset_config]
+[data_request.infer.data.dataset_config.applecider.image_and_metadata_dataset]
 use_oversampling = false
-
-[data_set."applecider.datasets.image_and_metadata_dataset.ImageAndMetadataDataset"]
-class_distribution = [0.3, 0.1, 0.1, 0.3, 0.1]

--- a/docs/pre_executed/testing/baselineCLS_example.py
+++ b/docs/pre_executed/testing/baselineCLS_example.py
@@ -46,7 +46,5 @@ h.train()
 
 # Inference
 h.set_config("model.HyraxBaselineCLS.use_probabilities", True)
-h.set_config(
-    "applecider.photo_dataset.use_oversampling", False
-)  # Disable oversampling for inference
+h.set_config("applecider.photo_dataset.use_oversampling", False)  # Disable oversampling for inference
 h.infer()

--- a/docs/pre_executed/testing/baselineCLS_example.py
+++ b/docs/pre_executed/testing/baselineCLS_example.py
@@ -41,12 +41,12 @@ if perform_pretrain:
 
 # Training
 h.set_config("model.HyraxBaselineCLS.use_probabilities", False)
-h.set_config("data_set.'applecider.datasets.photo_dataset.PhotoEventsDataset'.use_oversampling", True)
+h.set_config("applecider.photo_dataset.use_oversampling", True)
 h.train()
 
 # Inference
 h.set_config("model.HyraxBaselineCLS.use_probabilities", True)
 h.set_config(
-    "data_set.'applecider.datasets.photo_dataset.PhotoEventsDataset'.use_oversampling", False
+    "applecider.photo_dataset.use_oversampling", False
 )  # Disable oversampling for inference
 h.infer()

--- a/docs/pre_executed/testing/baselinecls_example_config.toml
+++ b/docs/pre_executed/testing/baselinecls_example_config.toml
@@ -5,32 +5,33 @@ name = "applecider.models.HyraxBaselineCLS.HyraxBaselineCLS"
 
 [data_loader]
 batch_size = 128
-collate_fn = "applecider.datasets.photo_dataset.collate"
 
-[model_inputs]
-[model_inputs.train.data]
+[data_request]
+[data_request.train.data]
 dataset_class = "applecider.datasets.photo_dataset.PhotoEventsDataset"
 data_location = "../../../data/photo_events/train/"
 fields = ["photometry", "label", "mean", "std"]
 primary_id_field = "object_id"
-[model_inputs.train.data.dataset_config]
+split_fraction = 0.8
+[data_request.train.data.dataset_config.applecider.photo_dataset]
 manifest_path = "../../../data/photo_events/manifest_train.csv"
 
-[model_inputs.validate.data]
-#[model_inputs.dont_use.data]
+[data_request.validate.data]
+#[data_request.dont_use.data]
 dataset_class = "applecider.datasets.photo_dataset.PhotoEventsDataset"
 data_location = "../../../data/photo_events/val/"
 fields = ["photometry", "label", "mean", "std"]
 primary_id_field = "object_id"
-[model_inputs.validate.data.dataset_config]
+split_fraction = 0.2
+[data_request.validate.data.dataset_config.applecider.photo_dataset]
 manifest_path = "../../../data/photo_events/manifest_val.csv"
 
-[model_inputs.infer.data]
+[data_request.infer.data]
 dataset_class = "applecider.datasets.photo_dataset.PhotoEventsDataset"
 data_location = "../../../data/photo_events/test/"
 fields = ["photometry", "mean", "std"]
 primary_id_field = "object_id"
-[model_inputs.infer.data.dataset_config]
+[data_request.infer.data.dataset_config.applecider.photo_dataset]
 manifest_path = "../../../data/photo_events/manifest_test.csv"
 use_oversampling = false
 

--- a/docs/pre_executed/testing/spectranet_testing_runtime_config.toml
+++ b/docs/pre_executed/testing/spectranet_testing_runtime_config.toml
@@ -1,18 +1,19 @@
 [model]
 name = "applecider.models.spectranet.SpectraNet"
 
-[model_inputs]
-
-[model_inputs.train.data]
+[data_request.train.data]
 dataset_class = "applecider.datasets.spectra_dataset.SpectraData"
 fields = ["flux", "label", "redshift"]
 data_location = "../../../data/spectra_data/train.pt"
+primary_id_field = "object_id"
+split_fraction = 1.0
 
-[model_inputs.infer.data]
+[data_request.infer.data]
 dataset_class = "applecider.datasets.spectra_dataset.SpectraData"
 fields = ["flux"]
 data_location = "../../../data/spectra_data/test.pt"
 primary_id_field = "object_id"
+split_fraction = 1.0
 
 [train]
 epochs = 1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ classifiers = [
     "Programming Language :: Python",
 ]
 dynamic = ["version"]
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 dependencies = [
     "hyrax",
     "matplotlib",

--- a/src/applecider/datasets/image_and_metadata_dataset.py
+++ b/src/applecider/datasets/image_and_metadata_dataset.py
@@ -19,9 +19,7 @@ CLASSES = [
 
 class ImageAndMetadataDataset(HyraxDataset, OversamplerMixin):
     def __init__(self, config, data_location):
-        self.dataset_config = config["data_set"][
-            "applecider.datasets.image_and_metadata_dataset.ImageAndMetadataDataset"
-        ]
+        self.dataset_config = config["applecider"]["image_and_metadata_dataset"]
 
         self.all_samples = self.dataset_config["all_samples"]
         self.augment = self.dataset_config["augment"]
@@ -59,13 +57,13 @@ class ImageAndMetadataDataset(HyraxDataset, OversamplerMixin):
         super().__init__(config)
         # Additional initialization for image and metadata dataset can be added here
 
-    def get_metadata(self, index):
+    def get_metadata(self, index) -> np.ndarray:
         # Method to retrieve metadata at the specified index
         if self.use_oversampling:
             index, is_oversampled = self.retrieve_oversampled_index(index)
-        return self.raw_files[index].get("metadata")
+        return self.raw_files[index].get("metadata").numpy()
 
-    def get_image(self, index):
+    def get_image(self, index) -> np.ndarray:
         # Method to retrieve image at the specified index
         if self.use_oversampling:
             index, is_oversampled = self.retrieve_oversampled_index(index)
@@ -101,9 +99,9 @@ class ImageAndMetadataDataset(HyraxDataset, OversamplerMixin):
             if self.enable_cache:
                 self.image_cache[index] = image
 
-        return image
+        return image.numpy()
 
-    def get_target(self, index):
+    def get_target(self, index) -> np.ndarray:
         """The `target` is broad class category of the object.
 
         Parameters
@@ -127,7 +125,7 @@ class ImageAndMetadataDataset(HyraxDataset, OversamplerMixin):
 
         return target
 
-    def get_real_target(self, index):
+    def get_real_target(self, index) -> np.ndarray:
         """The `real_target` is the fine-grained classification of the object.
 
         Parameters
@@ -151,16 +149,11 @@ class ImageAndMetadataDataset(HyraxDataset, OversamplerMixin):
 
         return real_target
 
-    def get_obj_id(self, index):
+    def get_obj_id(self, index) -> str:
         # Method to retrieve object ID at the specified index
         if self.use_oversampling:
             index, is_oversampled = self.retrieve_oversampled_index(index)
-        return self.raw_files[index].get("obj_id")
-
-    def ids(self):
-        # Generator to yield all object IDs in the dataset
-        for idx in range(len(self)):
-            yield self.get_obj_id(idx)
+        return str(self.raw_files[index].get("obj_id"))
 
     def __len__(self):
         # Return the total number of items in the dataset
@@ -168,7 +161,3 @@ class ImageAndMetadataDataset(HyraxDataset, OversamplerMixin):
             return self.total_count_with_oversampling
         else:
             return len(self.raw_files)
-
-    def __getitem__(self, index):
-        # Unused, but required by Hyrax to show inheritance from PyTorch Dataset.
-        pass

--- a/src/applecider/datasets/image_and_metadata_dataset.py
+++ b/src/applecider/datasets/image_and_metadata_dataset.py
@@ -3,7 +3,7 @@ import os
 import numpy as np
 import torch
 from applecider.datasets.oversampler_mixin import OversamplerMixin
-from hyrax.data_sets.data_set_registry import HyraxDataset
+from hyrax.datasets import HyraxDataset
 
 EPS = 1e-8  # Small value to prevent division by zero
 REAL_CLASSES = ["AGN", "TDE", "SN II", "SN IIp", "SN Ia", "SN IIn", "SN Ib", "SN Ic", "Cataclysmic"]

--- a/src/applecider/datasets/image_and_metadata_dataset.py
+++ b/src/applecider/datasets/image_and_metadata_dataset.py
@@ -61,7 +61,7 @@ class ImageAndMetadataDataset(HyraxDataset, OversamplerMixin):
         # Method to retrieve metadata at the specified index
         if self.use_oversampling:
             index, is_oversampled = self.retrieve_oversampled_index(index)
-        return self.raw_files[index].get("metadata").numpy()
+        return np.asarray(self.raw_files[index].get("metadata"))
 
     def get_image(self, index) -> np.ndarray:
         # Method to retrieve image at the specified index
@@ -99,7 +99,7 @@ class ImageAndMetadataDataset(HyraxDataset, OversamplerMixin):
             if self.enable_cache:
                 self.image_cache[index] = image
 
-        return image.numpy()
+        return np.asarray(image)
 
     def get_target(self, index) -> np.ndarray:
         """The `target` is broad class category of the object.

--- a/src/applecider/datasets/photo_dataset.py
+++ b/src/applecider/datasets/photo_dataset.py
@@ -4,7 +4,7 @@ from typing import Union
 import numpy as np
 import pandas as pd
 from applecider.datasets.oversampler_mixin import OversamplerMixin
-from hyrax.data_sets import HyraxDataset
+from hyrax.datasets import HyraxDataset
 from torch.utils.data import Dataset
 
 

--- a/src/applecider/datasets/photo_dataset.py
+++ b/src/applecider/datasets/photo_dataset.py
@@ -45,14 +45,12 @@ class PhotoEventsDataset(HyraxDataset, Dataset, OversamplerMixin):
     def get_object_id(self, idx) -> str:
         """get unique identifier for a specific index"""
         # Find the row in the manifest ids
-        old_idx = idx
         if self.use_oversampling:
             idx, is_oversampled = self.retrieve_oversampled_index(idx)
         return str(self.object_ids[idx])
 
     def get_label(self, idx):
         """get ID label for a specific index"""
-        old_idx = idx
         if self.use_oversampling:
             idx, is_oversampled = self.retrieve_oversampled_index(idx)
         # Find the row in the manifest

--- a/src/applecider/datasets/photo_dataset.py
+++ b/src/applecider/datasets/photo_dataset.py
@@ -13,7 +13,7 @@ class PhotoEventsDataset(HyraxDataset, Dataset, OversamplerMixin):
         self.data_location = data_location
         self.filenames = sorted(list(Path(self.data_location).glob("*.npz")))
 
-        self.photo_config = config["data_set"]["applecider.datasets.photo_dataset.PhotoEventsDataset"]
+        self.photo_config = config["applecider"]["photo_dataset"]
 
         self.manifest_df = pd.read_csv(self.photo_config["manifest_path"])
         self.manifest_df = self.manifest_df.sort_values("obj_id", inplace=False)
@@ -42,21 +42,13 @@ class PhotoEventsDataset(HyraxDataset, Dataset, OversamplerMixin):
             self.prepare_over_sampling(ideal_class_distribution, class_at_index)
         super().__init__(config)
 
-    def __getitem__(self, idx):
-        # getting happens via the getter methods below
-        pass
-
-    def get_object_id(self, idx):
+    def get_object_id(self, idx) -> str:
         """get unique identifier for a specific index"""
         # Find the row in the manifest ids
         old_idx = idx
         if self.use_oversampling:
             idx, is_oversampled = self.retrieve_oversampled_index(idx)
-        return self.object_ids[idx]
-
-    def ids(self):
-        for idx in range(len(self)):
-            yield self.get_object_id(idx)
+        return str(self.object_ids[idx])
 
     def get_label(self, idx):
         """get ID label for a specific index"""

--- a/src/applecider/datasets/photo_dataset.py
+++ b/src/applecider/datasets/photo_dataset.py
@@ -92,29 +92,10 @@ class PhotoEventsDataset(HyraxDataset, Dataset, OversamplerMixin):
         # Result is a (L, 7) tensor (L = sequence length)
         return np.concatenate([vec4, one_hot_band], 1)  # (L, 7)
 
-    def get_mean(self, idx):
-        """get feature means from stats file"""
-        return self.st["mean"]
-
-    def get_std(self, idx):
-        """get feature standard deviations from stats file"""
-        return self.st["std"]
-
-    def __len__(self):
-        if self.use_oversampling:
-            return self.total_count_with_oversampling
-        else:
-            return len(self.filenames)
-
     @staticmethod
-    def collate(batch):
-        """custom collate function for photo events dataset"""
-        seqs = []
-        labels = []
-        for i in batch:
-            seqs += [i["data"]["photometry"]]
-            if "label" in i["data"]:
-                labels += [i["data"]["label"]]
+    def collate_photometry(batch):
+        """custom collate function for photometry data"""
+        seqs = [i["photometry"] for i in batch]
 
         lengths = [s.shape[0] for s in seqs]
         max_len = max([257, max(lengths)])
@@ -134,11 +115,22 @@ class PhotoEventsDataset(HyraxDataset, Dataset, OversamplerMixin):
         pad_mask = pad_mask[:, :257]
 
         return {
-            "data": {
-                "photometry": pad,
-                "label": np.array(labels),
-                "pad_mask": pad_mask,
-                "mean": np.array(batch[0]["data"]["mean"]),
-                "std": np.array(batch[0]["data"]["std"]),
-            },
+            "photometry": pad,
+            "pad_mask": pad_mask,
         }
+
+    def get_mean(self, idx):
+        """get feature means from stats file"""
+        # TODO: Double check this reshaping!!!
+        return self.st["mean"].reshape(1, 4)
+
+    def get_std(self, idx):
+        """get feature standard deviations from stats file"""
+        # TODO: Double check this reshaping!!!
+        return self.st["std"].reshape(1, 4)
+
+    def __len__(self):
+        if self.use_oversampling:
+            return self.total_count_with_oversampling
+        else:
+            return len(self.filenames)

--- a/src/applecider/datasets/spectra_dataset.py
+++ b/src/applecider/datasets/spectra_dataset.py
@@ -1,13 +1,11 @@
 import numpy as np
 import torch
-from hyrax.data_sets.data_set_registry import HyraxDataset
+from hyrax.datasets import HyraxDataset
 from torch.utils.data import Dataset
 
 
 class SpectraData(HyraxDataset, Dataset):
     def __init__(self, config, data_location=None):
-        super().__init__(config)
-
         data_table = torch.load(data_location)
 
         # Used for casting the classification labels into an

--- a/src/applecider/default_config.toml
+++ b/src/applecider/default_config.toml
@@ -119,8 +119,7 @@ class_order = 9
 flat_dim = 3072
 
 
-[data_set."applecider.datasets.image_and_metadata_dataset.ImageAndMetadataDataset"]
-
+[applecider.image_and_metadata_dataset]
 # Defines the maximum number of alerts per sample to work with. Use <= 0 for all available alerts.
 alert = 0
 
@@ -149,8 +148,7 @@ patch_size = [32, 32]
 tags = []
 
 
-[data_set."applecider.datasets.photo_dataset.PhotoEventsDataset"]
-
+[applecider.photo_dataset]
 manifest_path = "../../../data/photo_events/manifest_train.csv"
 
 stats_path = "../../../data/photo_events/feature_stats_day100.npz"

--- a/src/applecider/models/HyraxBaselineCLS.py
+++ b/src/applecider/models/HyraxBaselineCLS.py
@@ -165,7 +165,7 @@ class HyraxBaselineCLS(nn.Module):
 
         # Generate all-false padding mask if not provided, useful for infer step
         # The +1 is to account for the CLS token added in the model.
-        false_mask = np.zeros((photo_tensor.shape[0], photo_tensor.shape[1] + 1), dtype=bool)
+        false_mask = np.zeros((photo_tensor.shape[0], photo_tensor.shape[1]), dtype=bool)
         return (photo_tensor, false_mask, label_tensor)
 
 

--- a/src/applecider/models/HyraxBaselineCLS.py
+++ b/src/applecider/models/HyraxBaselineCLS.py
@@ -85,7 +85,7 @@ class HyraxBaselineCLS(nn.Module):
             output = F.softmax(output, dim=1)
         return output
 
-    def train_step(self, batch):
+    def train_batch(self, batch):
         """
         This function contains the logic for a single training step. i.e. the
         contents of the inner loop of a ML training process.
@@ -119,8 +119,11 @@ class HyraxBaselineCLS(nn.Module):
         # accuracy, total loss/tot n, any custom metrics
         return {"loss": loss.item(), "num_tdes": np.sum([labels.cpu().numpy() == 4])}
 
+    def infer_batch(self, batch):
+        return self.forward(batch)
+
     @staticmethod
-    def to_tensor(data_dict):
+    def prepare_inputs(data_dict):
         """
         Converts raw data from a dictionary into a PyTorch tensor suitable for the model.
 
@@ -231,7 +234,7 @@ class MPTModel(nn.Module):
     def forward(self, z):
         return self.head_flux(z), self.head_band(z), self.head_dt(z)
 
-    def train_step(self, batch):
+    def train_batch(self, batch):
         data = batch[0]
         pad = batch[1]
         # import pdb;pdb.set_trace()
@@ -283,6 +286,9 @@ class MPTModel(nn.Module):
 
         return {"loss": loss.item()}
 
+    def infer_batch(self, batch):
+        return self.forward(batch)
+
     def _mask_batch(self, x, pad_mask):
         MASK_P = self.config["model"]["HyraxBaselineCLS"]["mask_p"]
         masked = torch.zeros_like(pad_mask)
@@ -319,7 +325,7 @@ class MPTModel(nn.Module):
         return masked
 
     @staticmethod
-    def to_tensor(data_dict):
+    def prepare_inputs(data_dict):
         """
         Converts raw data from a dictionary into a PyTorch tensor suitable for the model.
 

--- a/src/applecider/models/HyraxBaselineCLS.py
+++ b/src/applecider/models/HyraxBaselineCLS.py
@@ -278,7 +278,7 @@ class MPTModel(nn.Module):
         lambda_f = self.config["model"]["HyraxBaselineCLS"]["lambda_f"]
         lambda_b = self.config["model"]["HyraxBaselineCLS"]["lambda_b"]
         lambda_dt = self.config["model"]["HyraxBaselineCLS"]["lambda_dt"]
-        loss = lambda_f * loss_f * lambda_b * loss_b * lambda_dt * loss_dt
+        loss = lambda_f * loss_f + lambda_b * loss_b + lambda_dt * loss_dt
         self.optimizer.zero_grad()
         loss.backward()
         torch.nn.utils.clip_grad_norm_(self.parameters(), max_norm=1.0)
@@ -332,7 +332,7 @@ class MPTModel(nn.Module):
         lambda_f = self.config["model"]["HyraxBaselineCLS"]["lambda_f"]
         lambda_b = self.config["model"]["HyraxBaselineCLS"]["lambda_b"]
         lambda_dt = self.config["model"]["HyraxBaselineCLS"]["lambda_dt"]
-        loss = lambda_f * loss_f * lambda_b * loss_b * lambda_dt * loss_dt
+        loss = lambda_f * loss_f + lambda_b * loss_b + lambda_dt * loss_dt
 
         return {"loss": loss.item()}
 

--- a/src/applecider/models/HyraxBaselineCLS.py
+++ b/src/applecider/models/HyraxBaselineCLS.py
@@ -286,6 +286,56 @@ class MPTModel(nn.Module):
 
         return {"loss": loss.item()}
 
+    def validate_batch(self, batch):
+        """This is identical to train_batch but without the backward pass and
+        optimizer step. We can also compute any validation metrics here."""
+        data = batch[0]
+        pad = batch[1]
+        # import pdb;pdb.set_trace()
+        masked_tok = self._mask_batch(data, pad)
+
+        B, L, _ = data.shape
+
+        # project into model dim
+        emb = self.in_proj(data)  # (B, L, d_model)
+        # extract the *continuous* log1p dt feature
+        t = data[..., 0]
+
+        # compute the learned time embedding:
+        te = self.time2vec(t)
+        te = F.dropout(te, p=self.config["model"]["HyraxBaselineCLS"]["dropout"])
+
+        # add it:
+        h_in = emb + te  # (B, L, d_model)
+        # prepend a learned CLS token:
+        tok = self.cls_tok.expand(B, -1, -1)  # (B,1,d_model)
+        h = torch.cat([tok, h_in], dim=1)  # (B, L+1, d_model)
+        pad = torch.cat([pad.new_zeros((B, 1)), pad], 1)
+
+        # encode
+        z_full = self.encoder(h, src_key_padding_mask=pad)  # (B, L+1, d_model)
+        h_masked = z_full[:, 1:, :]  # (B, L, d_model)
+        f_hat = self.head_flux(h_masked)  # (B, L, 1)
+        b_hat = self.head_band(h_masked)  # (B, L, 3)
+        dt_hat = self.head_dt(h_masked)  # (B, L, 1)
+
+        mf = masked_tok.contiguous().view(-1)
+        true_f = data[..., 2].view(-1)
+        loss_f = F.mse_loss(f_hat.view(-1)[mf], true_f[mf])
+        true_b = data[..., 4:7].argmax(-1).view(-1)
+        loss_b = F.cross_entropy(b_hat.view(-1, 3)[mf], true_b[mf])
+        dt_gt = torch.roll(data[..., 1], -1, dims=1)
+        dt_gt[:, -1] = 0.0
+        dt_gt = dt_gt.view(-1)
+        loss_dt = F.mse_loss(dt_hat[..., 0].view(-1)[mf], dt_gt[mf])
+
+        lambda_f = self.config["model"]["HyraxBaselineCLS"]["lambda_f"]
+        lambda_b = self.config["model"]["HyraxBaselineCLS"]["lambda_b"]
+        lambda_dt = self.config["model"]["HyraxBaselineCLS"]["lambda_dt"]
+        loss = lambda_f * loss_f * lambda_b * loss_b * lambda_dt * loss_dt
+
+        return {"loss": loss.item()}
+
     def infer_batch(self, batch):
         return self.forward(batch)
 

--- a/src/applecider/models/astrominn.py
+++ b/src/applecider/models/astrominn.py
@@ -305,7 +305,7 @@ class AstroMiNN(nn.Module):
     def _calculate_stats(self):
         return sum(self.total_loss) / len(self.total_loss)
 
-    def train_step(self, batch):
+    def train_batch(self, batch):
         _, _, labels = batch
 
         self.this_optimizer.zero_grad()
@@ -325,8 +325,11 @@ class AstroMiNN(nn.Module):
 
         return {"loss": loss}
 
+    def infer_batch(self, batch):
+        return self.forward(batch)
+
     @staticmethod
-    def to_tensor(data_dict: dict) -> tuple:
+    def prepare_inputs(data_dict: dict) -> tuple:
         """Convert input data dictionary to a tuple of numpy arrays for model
         processing.
         """

--- a/src/applecider/models/spectranet.py
+++ b/src/applecider/models/spectranet.py
@@ -169,7 +169,7 @@ class SpectraNet(nn.Module):
         else:
             return self.classifier(x_fused)
 
-    def train_step(self, batch):
+    def train_batch(self, batch):
         # spectranet uses the `train_one_epoch` function in utils.py
         _, labels, redshifts = batch
 
@@ -183,8 +183,11 @@ class SpectraNet(nn.Module):
         self.optimizer.step()
         return {"loss": loss.item()}
 
+    def infer_batch(self, batch):
+        return self.forward(batch)
+
     @staticmethod
-    def to_tensor(data_dict):
+    def prepare_inputs(data_dict):
         """This method will receive a dictionary of data and should convert it
         to the relevant numpy arrays needed for either training or inference."""
 


### PR DESCRIPTION
# Updating AppleCider to use the current version of Hyrax (v0.8.3)
- Updated dataset classes to import `dataset` instead of `data_set`
- Updated models
  - Renamed `train_step` to `train_batch`
  - Added `infer_batch` (just calls `forward`)
  - Renamed `to_tensor` to `prepare_inputs`
- Updated smoke tests, unit tests, and pyproject.toml to specify python >= 3.11
- Updated `model_input`s to `data_request`s in the example notebook and configs
- Made sure that example notebooks can run (just a smoke test)
- Verified `to_onnx` and `engine` still work
- Removed dataset-level `collate` from photo_dataset, replaced with `collate_photometry`.
- Double check the returned values from photo_dataset methods `get_mean` and `get_std`. I had to reshape them to get things to work.

## TODO
- Wait for Felipe to review the padding. 
- ~~Add `validate_batch` methods in astrominn and spectranet.~~ Won't do this, can revisit if we break apart this repo into distinct models.